### PR TITLE
fix: clicking max button when balance is 0 caused infinite load

### DIFF
--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -347,7 +347,7 @@ const AmountInput = forwardRef(
                 color: '#FFF',
               }}
               onClick={handleMaxClick}
-              isDisabled={isLoading || balData.isError}
+              isDisabled={isLoading || balData.isError || balance.isZero()}
               aria-label="Set maximum amount"
             >
               Max
@@ -635,7 +635,7 @@ const AmountInput = forwardRef(
             color="red"
             fontSize={'13px'}
           >
-            Amount must be less than {maxAmount.toEtherToFixedDecimals(2)}
+            Amount must be less than {maxAmount.toEtherToFixedDecimals(4)}
           </Text>
         )}
       </Box>

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -304,7 +304,7 @@ const AmountInput = forwardRef(
         <Box color={'light_grey'} textAlign={'right'}>
           <Text fontSize={'12px'}>Available balance </Text>
           <LoadingWrap
-            isLoading={false}
+            isLoading={isLoading}
             isError={balData.isError}
             skeletonProps={{
               height: '10px',

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -304,7 +304,7 @@ const AmountInput = forwardRef(
         <Box color={'light_grey'} textAlign={'right'}>
           <Text fontSize={'12px'}>Available balance </Text>
           <LoadingWrap
-            isLoading={isLoading}
+            isLoading={false}
             isError={balData.isError}
             skeletonProps={{
               height: '10px',

--- a/src/components/Redeem.tsx
+++ b/src/components/Redeem.tsx
@@ -574,13 +574,18 @@ function InternalRedeem(props: RedeemProps) {
                     maxHeight={'21px'}
                     fontSize={'12px'}
                     fontWeight={'400'}
+                    _active={{
+                      bg: '#323232',
+                      color: '#FFF',
+                    }}
                     _hover={{
                       bg: '#323232',
                       color: '#FFF',
                     }}
                     onClick={handleMaxClick}
+                    isDisabled={balance.isZero()}
                   >
-                    MAX
+                    Max
                   </Button>
                 </LoadingWrap>
               </Box>
@@ -607,7 +612,7 @@ function InternalRedeem(props: RedeemProps) {
                   size="sm"
                   width="80px"
                   height={'42px'}
-                  isDisabled={isLoading}
+                  isDisabled={isLoading || balance.isZero()}
                   keepWithinRange={false}
                   clampValueOnBlur={false}
                 >
@@ -664,7 +669,7 @@ function InternalRedeem(props: RedeemProps) {
               min={0}
               max={100}
               step={1}
-              isDisabled={isLoading}
+              isDisabled={isLoading || balance.isZero()}
             >
               <SliderTrack bg="#323232" height="6px">
                 <SliderFilledTrack bg="linear-gradient(to right, #2E45D0, #B1525C)" />


### PR DESCRIPTION
### PR Fixes:
- disable max button when balance is 0
- update "amount should be less than balance" error text to match decimal of available balance
- disable slider and input in withdraw tab when the balance is 0
- Align Max button text to be "Max" on both deposit and withdraw tabs

Resolves issues 10 + 7 from https://docs.google.com/spreadsheets/d/1N4LcHNpY3IGxyNHdfsSp36dKs0cxO7ZWBLSymN6BM_U/edit?gid=1389265471#gid=1389265471


### Checklist before requesting a review
- [ ] I have performed a self-review of my code
- [ ] I assure there is no similar/duplicate pull request regarding same issue
- [ ] My PR passes all checks (build, lint, formatting, etc)