### PR TITLE
prevent errors of onAmount change and prevent focus issues on percent…

### DIFF
--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -496,6 +496,7 @@ const AmountInput = forwardRef(
                   ...item,
                   isMaxClicked: false,
                   rawAmount: '',
+                  tokenInfo: props.strategy.metadata.depositTokens[index],
                 },
               });
             });

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -520,7 +520,7 @@ const AmountInput = forwardRef(
             address,
           });
         },
-        400,
+        500,
       ),
       [],
     ); // ms delay


### PR DESCRIPTION
prevent errors of onAmountChange and prevent focus issues on percent change
this is done by:
ensuring the percent input and is not disabled on each value update (for typing)
ensuring the slider is not disabled for each value update
making token values imported from the props to be passed to calculation methods
handle empty inputs
increasing debounce for long press handling