### PR TITLE
Deposit input formatting corrections

### DIFF
--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -296,9 +296,10 @@ const AmountInput = forwardRef(
                 info: {
                   ..._inputsInfo[_index],
                   ...item,
-                  rawAmount: Number(
-                    item.amount.toFixed(item.tokenInfo.decimals),
-                  ).toString(),
+                  rawAmount: Number(item.amount).toLocaleString('en-US', {
+                    useGrouping: false,
+                    maximumFractionDigits: props.tokenInfo.decimals, // set higher if needed
+                  }),
                 },
               });
             });
@@ -636,6 +637,11 @@ const AmountInput = forwardRef(
             height={'60px'}
             borderRadius={'10px'}
             placeholder="Amount"
+            onKeyDown={(e) => {
+              if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
+                e.preventDefault();
+              }
+            }}
           />
         </NumberInput>
 

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -91,7 +91,7 @@ const AmountInput = forwardRef(
 
       const inputItem = inputsInfo[props.index];
       const roundedAmount = Number(
-        inputItem.amount.toFixed(inputItem.tokenInfo?.decimals || 18),
+        inputItem.amount.toFixed(props.tokenInfo.decimals),
       );
       const isGreaterThanZero = roundedAmount > 0;
 

--- a/src/components/Redeem.tsx
+++ b/src/components/Redeem.tsx
@@ -400,7 +400,9 @@ function InternalRedeem(props: RedeemProps) {
               info: {
                 ..._inputsInfo[_index],
                 ...item,
-                rawAmount: Number(item.amount.toFixed(6)).toString(),
+                rawAmount: Number(
+                  item.amount.toFixed(item.tokenInfo.decimals),
+                ).toString(),
               },
             });
           });

--- a/src/strategies/ekubo_cl_vault.ts
+++ b/src/strategies/ekubo_cl_vault.ts
@@ -159,7 +159,7 @@ export class EkuboClStrategy extends IStrategy<CLVaultStrategySettings> {
     console.log(
       'onAmountsChange [1.2]',
       [input.token0, input.token1].map((item) => ({
-        amount: item.amount.toFixed(6),
+        amount: item.amount.toFixed(item.tokenInfo.decimals),
         tokenInfo: item.tokenInfo,
       })),
     );
@@ -167,7 +167,7 @@ export class EkuboClStrategy extends IStrategy<CLVaultStrategySettings> {
     console.log(
       'onAmountsChange [1.3]',
       [output.token0, output.token1].map((item) => ({
-        amount: item.amount.toFixed(6),
+        amount: item.amount.toFixed(item.tokenInfo.decimals),
         tokenInfo: item.tokenInfo,
       })),
     );

--- a/src/utils/MyNumber.ts
+++ b/src/utils/MyNumber.ts
@@ -18,7 +18,7 @@ export default class MyNumber {
   static fromEther(num: string, decimals: number) {
     try {
       return new MyNumber(
-        Number(ethers.parseUnits(num, decimals)).toFixed(6),
+        Number(ethers.parseUnits(num, decimals)).toFixed(decimals),
         decimals,
       );
     } catch (e) {
@@ -70,7 +70,7 @@ export default class MyNumber {
   }
 
   operate(command: 'div' | 'plus' | 'mul', value: string | number) {
-    const bn = new BigNumber(Number(value).toFixed(6));
+    const bn = new BigNumber(Number(value).toFixed(this.decimals));
     return new MyNumber(this.bigNumber[command](bn).toFixed(0), this.decimals);
   }
 


### PR DESCRIPTION
proper formatting of decimals and showing error when value is 0 after rounding (for example, small amount of STRK against USDC)

when small decimal amounts are displayed they are displayed correctly and not in scientific notation

prevented up/down arrow keys altering amount as the changes were unpredictable (unless using whole numbers)


