### PR TITLE
fix: redeem logic for two tokens

### DIFF
--- a/src/components/Redeem.tsx
+++ b/src/components/Redeem.tsx
@@ -431,7 +431,7 @@ function InternalRedeem(props: RedeemProps) {
                 amount2,
                 address: address || '0x0',
                 provider,
-                isMax: false,
+                isMax: isMaxClicked,
               });
 
               setCallsInfo(updatedCalls);

--- a/src/strategies/ekubo_cl_vault.ts
+++ b/src/strategies/ekubo_cl_vault.ts
@@ -245,7 +245,7 @@ export class EkuboClStrategy extends IStrategy<CLVaultStrategySettings> {
 
     console.log('Withdraw calls [1]');
     const amt = Web3Number.fromWei(amount.toString(), amount.decimals);
-    const amt2 = Web3Number.fromWei(amount2.toString(), amount.decimals);
+    const amt2 = Web3Number.fromWei(amount2.toString(), amount2.decimals);
     const calls = await this.clVault.withdrawCall(
       {
         token0: {


### PR DESCRIPTION
add logic for updating callsInfo when amount on redeem changes, furthermore also ensures that we include the expected amounts to be withdrawn from both token types so the call to the contract can be performed as a correct multicall