### PR TITLE
fix: handle unexpected cases from ekubo api

### DIFF
--- a/src/store/utils.atoms.ts
+++ b/src/store/utils.atoms.ts
@@ -114,7 +114,9 @@ export const userStatsAtom = atomWithQuery((get) => ({
       'Error fetching user stats',
     );
     if (!res) return null;
-    return await res.json();
+    const data: UserStats = await res.json();
+    if (data.holdingsUSD !== 0 && !data.holdingsUSD) return null;
+    return data;
   },
 }));
 
@@ -135,7 +137,7 @@ export const userStrategyWiseTVLAtom = atomFamily((strategyId: string) => {
       (s) => s.id === strategyId,
     );
     return {
-      data: strategy ? strategy.usdValue : 0,
+      data: strategy && strategy.usdValue ? strategy.usdValue : 0,
       isPending,
       error,
     };


### PR DESCRIPTION
we got some unexpected nulls in a response from the stats API, this can better handle them without completely crashing the app