### PR TITLE
fix: handle graph ql loading errors

### DIFF
--- a/src/hooks/useStrategiesInfo.ts
+++ b/src/hooks/useStrategiesInfo.ts
@@ -88,11 +88,6 @@ const useVolume = (fees?: Record<string, number>) => {
   const [isLoading, setIsLoading] = useState<Record<string, boolean>>({});
   const strategies = useMemo(getStrategies, []);
   useEffect(() => {
-    if (fees === undefined || Object.keys(fees).length === 0) {
-      setIsLoading({});
-      setVolume({});
-      return;
-    }
     strategies.forEach((strategy) => {
       const contract = strategy.metadata.address.toString();
       setIsLoading((prev) => ({ ...prev, [contract]: true }));
@@ -160,7 +155,7 @@ export const useStrategiesInfo = (
       },
       volume: {
         amount: volume?.[contract] || 0,
-        isLoading: volumeLoading[contract] ?? true,
+        isLoading: volumeLoading[contract] ?? false,
       },
     };
   });

--- a/src/store/transactions.atom.ts
+++ b/src/store/transactions.atom.ts
@@ -65,26 +65,35 @@ export const getFeesHistory = async (
   contract: string,
 ): Promise<ContractFeeEarnings> => {
   const contractAddrFormatted = standariseAddress(contract);
-  const { data } = await apolloClient.query({
-    query: gql`
-      query ContractFeeEarnings($timeframe: String!, $contract: String!) {
-        contractFeeEarnings(timeframe: $timeframe, contract: $contract) {
-          contract
-          dailyEarnings {
-            date
-            tokenAddress
-            amount
+  try {
+    const { data } = await apolloClient.query({
+      query: gql`
+        query ContractFeeEarnings($timeframe: String!, $contract: String!) {
+          contractFeeEarnings(timeframe: $timeframe, contract: $contract) {
+            contract
+            dailyEarnings {
+              date
+              tokenAddress
+              amount
+            }
+            totalCollections
           }
-          totalCollections
         }
-      }
-    `,
-    variables: {
-      contract: contractAddrFormatted,
-      timeframe: '24h',
-    },
-  });
-  return data.contractFeeEarnings;
+      `,
+      variables: {
+        contract: contractAddrFormatted,
+        timeframe: '24h',
+      },
+    });
+    return data.contractFeeEarnings;
+  } catch (error) {
+    console.error('GraphQL Error:', error);
+    return {
+      contract,
+      dailyEarnings: [],
+      totalCollections: '0',
+    };
+  }
 };
 
 export const getFeesHistoryAtom = (contracts: string[]) =>
@@ -133,36 +142,35 @@ export const getUserTxHistory = async (
   const contractAddrFormatted = standariseAddress(strategyContract);
   const ownerAddrFormatted = standariseAddress(owner);
   try {
-    const { data }: { data: { ekuboVaultFlows: EkuboVaultFlow[] } } =
-      await apolloClient.query({
-        query: gql`
-          query ContractFeeEarnings(
-            $userAddress: String!
-            $vaultContract: String!
+    const { data } = await apolloClient.query({
+      query: gql`
+        query ContractFeeEarnings(
+          $userAddress: String!
+          $vaultContract: String!
+        ) {
+          ekuboVaultFlows(
+            user_address: $userAddress
+            vault_contract: $vaultContract
           ) {
-            ekuboVaultFlows(
-              user_address: $userAddress
-              vault_contract: $vaultContract
-            ) {
-              type
-              txHash
-              block_number
-              txIndex
-              eventIndex
-              token0
-              token1
-              amount0
-              amount1
-              liquidity_delta
-              timestamp
-            }
+            type
+            txHash
+            block_number
+            txIndex
+            eventIndex
+            token0
+            token1
+            amount0
+            amount1
+            liquidity_delta
+            timestamp
           }
-        `,
-        variables: {
-          userAddress: ownerAddrFormatted,
-          vaultContract: contractAddrFormatted,
-        },
-      });
+        }
+      `,
+      variables: {
+        userAddress: ownerAddrFormatted,
+        vaultContract: contractAddrFormatted,
+      },
+    });
 
     return data.ekuboVaultFlows.map((tx: EkuboVaultFlow) => ({
       type: tx.type,
@@ -173,7 +181,7 @@ export const getUserTxHistory = async (
     }));
   } catch (error) {
     console.error('GraphQL Error:', error);
-    throw error;
+    return [];
   }
 };
 
@@ -226,7 +234,8 @@ export const UserDepsositsAtom = (
       queryFn: async (): Promise<Record<string, number>> => {
         const depositsPromises = strategyContracts.map(
           async (strategyContract, index) => {
-            const transactions = userTxHistory![strategyContract];
+            const transactions = userTxHistory?.[strategyContract];
+            if (!transactions) return 0;
             const token0 = tokenPrices?.find(
               (token) => token.tokenName === tokens[index][0],
             );

--- a/src/store/utils.atoms.ts
+++ b/src/store/utils.atoms.ts
@@ -155,13 +155,22 @@ export const tokenPricesAtom = atomWithQuery(() => ({
   queryKey: ['prices'],
   queryFn: async (): Promise<Price[]> => {
     const tokenPrices = TOKENS.map(async (token) => {
-      const price = await getPrice(token);
-      return {
-        tokenName: token.name,
-        tokenAddress: standariseAddress(token.token),
-        decimals: token.decimals,
-        price,
-      };
+      try {
+        const price = await getPrice(token);
+        return {
+          tokenName: token.name,
+          tokenAddress: standariseAddress(token.token),
+          decimals: token.decimals,
+          price,
+        };
+      } catch (e) {
+        return {
+          tokenName: token.name,
+          tokenAddress: standariseAddress(token.token),
+          decimals: token.decimals,
+          price: 0,
+        };
+      }
     });
     return await Promise.all(tokenPrices);
   },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -176,7 +176,11 @@ export function copyReferralLink(refCode: string) {
 export async function getPrice(tokenInfo: MyMultiTokenInfo, source?: string) {
   console.log(`getPrice::${source}`, tokenInfo.name);
   try {
-    return await getPriceFromMyAPI(tokenInfo);
+    const price = await getPriceFromMyAPI(tokenInfo);
+    if (isNaN(price)) {
+      throw new Error('Failed to fetch price');
+    }
+    return price;
   } catch (e) {
     console.warn('getPriceFromMyAPI error', e);
   }


### PR DESCRIPTION
small fix to prevent endless loading on graphQL errors and in instances when responses from Troves API are down again