### PR TITLE
feat: add 4 strkBTC Ekubo vaults; bump @strkfarm/sdk to 2.0.0-staging.68

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@reduxjs/toolkit": "^2.9.0",
     "@starknet-react/chains": "^5.0.3",
     "@starknet-react/core": "^5.0.3",
-    "@strkfarm/sdk": "^1.1.65",
+    "@strkfarm/sdk": "2.0.0-staging.68",
     "@tanstack/query-core": "5.28.0",
     "@types/mdx": "^2.0.13",
     "@types/mixpanel-browser": "2.49.0",

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -440,6 +440,13 @@ const AmountInput = forwardRef(
       ) {
         return;
       }
+      // SDK 2.0's assertValidDepositTokens reads tokenInfo.decimals on every
+      // entry, so skip the simulation until each input has resolved its
+      // tokenInfo (otherwise we crash with "Cannot read properties of null").
+      const isAllTokenInfosDefined = inputsInfo.every((item) => item.tokenInfo);
+      if (!isAllTokenInfosDefined) {
+        return;
+      }
       // simulate deposits using a large amount
       const amt = new Web3Number(10000000, props.tokenInfo.decimals);
       depositInfo
@@ -459,7 +466,7 @@ const AmountInput = forwardRef(
               };
             }
             return {
-              amount: Web3Number.fromWei('0', item.tokenInfo?.decimals || 0),
+              amount: Web3Number.fromWei('0', item.tokenInfo!.decimals),
               tokenInfo: item.tokenInfo!,
             };
           }),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,20 +1,8 @@
 import { constants, RpcProvider } from 'starknet';
+import { Global } from '@strkfarm/sdk';
 import { NFTInfo, TokenInfo } from './strategies/IStrategy';
 import { standariseAddress } from './utils';
 import MyNumber from './utils/MyNumber';
-
-const LOGOS = {
-  USDT: '/zklend/icons/tokens/usdt.svg?w=20',
-  USDC: '/zklend/icons/tokens/usdc.svg?w=20',
-  'USDC.e': '/zklend/icons/tokens/usdc.svg?w=20',
-  WBTC: '/zklend/icons/tokens/wbtc.svg?w=20',
-  tBTC: '/zklend/icons/tokens/wbtc.svg?w=20',
-  ETH: '/zklend/icons/tokens/eth.svg?w=20',
-  STRK: '/zklend/icons/tokens/strk.svg?w=20',
-  DAI: '/zklend/icons/tokens/dai.svg?w=20',
-  kSTRK: '/zklend/icons/tokens/kstrk.svg?w=20',
-  xSTRK: '/imagedelivery/c1f44170-c1b0-4531-3d3b-5f0bacfe1300/logo',
-};
 
 export type TokenName =
   | 'USDT'
@@ -26,7 +14,28 @@ export type TokenName =
   | 'tBTC'
   | 'DAI'
   | 'kSTRK'
-  | 'xSTRK';
+  | 'xSTRK'
+  | 'strkBTC';
+
+// Logos source from @strkfarm/sdk Global.getDefaultTokens() when available so
+// we don't have to keep parallel asset URLs in sync. DAI and kSTRK aren't in
+// the SDK token list, so they keep local fallbacks.
+const sdkLogo = (symbol: string) =>
+  Global.getDefaultTokens().find((t) => t.symbol === symbol)?.logo;
+
+const LOGOS: Record<TokenName, string> = {
+  USDT: sdkLogo('USDT')!,
+  USDC: sdkLogo('USDC')!,
+  'USDC.e': sdkLogo('USDC.e')!,
+  WBTC: sdkLogo('WBTC')!,
+  tBTC: sdkLogo('tBTC')!,
+  ETH: sdkLogo('ETH')!,
+  STRK: sdkLogo('STRK')!,
+  DAI: '/zklend/icons/tokens/dai.svg?w=20',
+  kSTRK: '/zklend/icons/tokens/kstrk.svg?w=20',
+  xSTRK: sdkLogo('xSTRK')!,
+  strkBTC: sdkLogo('strkBTC')!,
+};
 
 export const CONSTANTS = {
   DEX_INCENTIVE_URL:
@@ -276,6 +285,19 @@ export const TOKENS: TokenInfo[] = [
     stepAmount: MyNumber.fromEther('10', 18),
     isERC4626: false,
   },
+  {
+    token: standariseAddress(
+      '0x787150e306e6eae6e3f79dea881770e8bbff2c1b8eb490f969669ee945b3135',
+    ),
+    name: 'strkBTC',
+    decimals: 8,
+    displayDecimals: 2,
+    logo: CONSTANTS.LOGOS.strkBTC,
+    minAmount: MyNumber.fromEther('0.00001', 8),
+    maxAmount: MyNumber.fromEther('10000', 8),
+    stepAmount: MyNumber.fromEther('0.00001', 8),
+    isERC4626: false,
+  },
 ];
 
 export const NFTS: NFTInfo[] = [
@@ -463,6 +485,38 @@ export const VAULTS: Vault[] = [
     launchBlock: 3998034,
     baseToken: 'USDC',
     quoteToken: 'WBTC',
+  },
+  {
+    name: 'strkBTC/USDC',
+    address:
+      '0x02dfe5af1665a7adf549008161c818eb18dcf89fc9518ab812294f2b691b2845',
+    launchBlock: 9650986,
+    baseToken: 'strkBTC',
+    quoteToken: 'USDC',
+  },
+  {
+    name: 'strkBTC/STRK',
+    address:
+      '0x04784e62a4847484528ba65f500b37a9347e88632e90d866e213f2c2651be828',
+    launchBlock: 9650592,
+    baseToken: 'strkBTC',
+    quoteToken: 'STRK',
+  },
+  {
+    name: 'strkBTC/ETH',
+    address:
+      '0x07118ecd7dece83462b0ac8302c682fb17c7e18b0be13d81867c5bf3f80933ef',
+    launchBlock: 9650986,
+    baseToken: 'strkBTC',
+    quoteToken: 'ETH',
+  },
+  {
+    name: 'WBTC/strkBTC',
+    address:
+      '0x07e927222730899442b2438bfd6218ff8ac44bd7a3420646fca359b8392e42c1',
+    launchBlock: 9650986,
+    baseToken: 'WBTC',
+    quoteToken: 'strkBTC',
   },
 ];
 

--- a/src/store/strategies.atoms.tsx
+++ b/src/store/strategies.atoms.tsx
@@ -3,7 +3,6 @@ import { IStrategyProps, StrategyLiveStatus } from '@/strategies/IStrategy';
 import { convertToV2TokenInfo, getTokenInfoFromName } from '@/utils';
 import { privatePoolsAtom } from './protocols';
 import { PoolInfo } from './pools';
-import { Box, Link } from '@chakra-ui/react';
 import { ContractAddr, EkuboCLVaultStrategies, Global } from '@strkfarm/sdk';
 import { atomWithQuery } from 'jotai-tanstack-query';
 import { EkuboClStrategy } from '@/strategies/ekubo_cl_vault';
@@ -15,134 +14,33 @@ export interface StrategyInfo<T> extends IStrategyProps<T> {
 }
 
 export function getStrategies() {
-  const alerts2: any[] = [
-    {
-      type: 'warning',
-      text: (
-        <Box>
-          Deposits are expected to fail for this strategy due to an ongoing
-          zkLend security incident until further notice.{' '}
-          <Link
-            href="https://x.com/strkfarm/status/1889526043733794979"
-            color="white"
-            fontWeight={'bold'}
-          >
-            Learn more
-          </Link>
-        </Box>
-      ),
-      tab: 'deposit',
-    },
-    {
-      type: 'warning',
-      text: (
-        <Box>
-          You will receive withdrawals as zTokens, redeemable on zkLend.
-          However, redemptions may be affected due to an ongoing security
-          incident.{' '}
-          <Link
-            href="https://x.com/strkfarm/status/1889526043733794979"
-            color="white"
-            fontWeight={'bold'}
-          >
-            Learn more
-          </Link>
-        </Box>
-      ),
-      tab: 'withdraw',
-    },
-  ];
-
-  const alerts: any[] = [
-    {
-      type: 'warning',
-      text: (
-        <Box>
-          Deposits and Withdraws are paused for this strategy due to zkLend
-          security incident until further notice.{' '}
-          <Link
-            href="https://x.com/strkfarm/status/1889526043733794979"
-            color="white"
-            fontWeight={'bold'}
-          >
-            Learn more
-          </Link>
-        </Box>
-      ),
-      tab: 'all',
-    },
-  ];
-
-  const strategyMetadata: IStrategyMetadata<CLVaultStrategySettings> = {
-    ...EkuboCLVaultStrategies[0],
-    name: 'Re7 Ekubo xSTRK/STRK',
-    description: `
-      Our vault puts your tokens to work in Ekubo pools to earn fees, auto-claims rewards, 
-      swaps to pool tokens, redeposits, and rebalances - all on-chain and non-custodial. 
-      An off-chain service safely automates harvesting and rebalancing, without ever holding your funds. 
-      You stay in control and can withdraw anytime.
-    `,
-    address: ContractAddr.from(
-      '0x0684f7fc8ebd6dae56bbae2ea21bc81b2c9c29d014c564a8ae90507ea6d2c4cc',
-    ),
-    launchBlock: 1446217,
-    depositTokens: [
-      // We support most blue chip tokens in this list, so, for any vault, u just need
-      // to specify the name
-      // ? The order of tokens is import. First is Ekubo poolKey token0, second is token1
-      // If token doesn't exist in our list, u can manually populate here as well
-      Global.getDefaultTokens().find((t) => t.symbol === 'xSTRK')!,
-      Global.getDefaultTokens().find((t) => t.symbol === 'STRK')!,
-    ],
-  };
-  const re7EkuboXSTRKSTRK = new EkuboClStrategy(
-    `Re7 Ekubo xSTRK/STRK`,
-    `Our vault puts your tokens to work in Ekubo pools to earn fees,
-        auto-claims rewards, swaps to pool tokens, redeposits, and rebalances -
-        all on-chain and non-custodial. An off-chain service safely automates
-        harvesting and rebalancing, without ever holding your funds. You stay in
-        control and can withdraw anytime.`,
-    strategyMetadata,
-    StrategyLiveStatus.HOT,
-    {
-      maxTVL: 0,
-      isAudited: EkuboCLVaultStrategies[0].auditUrl ? true : false,
-      auditUrl: EkuboCLVaultStrategies[0].auditUrl,
-      isPaused: false,
-      alerts: [
-        {
-          type: 'info',
-          text: 'Depending on the current position range and price, your input amounts are automatially adjusted to nearest required amounts',
-          tab: 'all',
-        },
-      ],
-      quoteToken: convertToV2TokenInfo(
-        getTokenInfoFromName('STRK'), // quote token for this strategy, used to denominate user holdings of the pool in this asset as a summary
-      ),
-      isTransactionHistDisabled: true,
-    },
-  );
-
   return VAULTS.map((vault) => {
+    // SDK 2.0 asserts depositTokens[0]/[1] match the on-chain Ekubo poolKey
+    // token0/token1, which Ekubo orders by ascending address. Sort here so
+    // VAULTS entries don't need to know about Ekubo's ordering convention.
+    const baseTokenInfo = Global.getDefaultTokens().find(
+      (t) => t.symbol === vault.baseToken,
+    )!;
+    const quoteTokenInfo = Global.getDefaultTokens().find(
+      (t) => t.symbol === vault.quoteToken,
+    )!;
+    const depositTokens =
+      baseTokenInfo.address.toBigInt() < quoteTokenInfo.address.toBigInt()
+        ? [baseTokenInfo, quoteTokenInfo]
+        : [quoteTokenInfo, baseTokenInfo];
+
     const strategyMetadata: IStrategyMetadata<CLVaultStrategySettings> = {
       ...EkuboCLVaultStrategies[0],
       name: vault.name,
       description: `
-        Our vault puts your tokens to work in Ekubo pools to earn fees, auto-claims rewards, 
-        swaps to pool tokens, redeposits, and rebalances - all on-chain and non-custodial. 
-        An off-chain service safely automates harvesting and rebalancing, without ever holding your funds. 
+        Our vault puts your tokens to work in Ekubo pools to earn fees, auto-claims rewards,
+        swaps to pool tokens, redeposits, and rebalances - all on-chain and non-custodial.
+        An off-chain service safely automates harvesting and rebalancing, without ever holding your funds.
         You stay in control and can withdraw anytime.
       `,
       address: ContractAddr.from(vault.address),
       launchBlock: vault.launchBlock,
-      depositTokens: [
-        // We support most blue chip tokens in this list, so, for any vault, u just need
-        // to specify the name
-        // ? The order of tokens is import. First is Ekubo poolKey token0, second is token1
-        // If token doesn't exist in our list, u can manually populate here as well
-        Global.getDefaultTokens().find((t) => t.symbol === vault.baseToken)!,
-        Global.getDefaultTokens().find((t) => t.symbol === vault.quoteToken)!,
-      ],
+      depositTokens,
     };
 
     return new EkuboClStrategy(

--- a/yarn.lock
+++ b/yarn.lock
@@ -2540,10 +2540,10 @@
     viem "^2.21.1"
     zod "^3.22.4"
 
-"@strkfarm/sdk@^1.1.65":
-  version "1.1.65"
-  resolved "https://registry.yarnpkg.com/@strkfarm/sdk/-/sdk-1.1.65.tgz#ba63b05c52e1076893f9765a546dc3e5c49303b0"
-  integrity sha512-wvV+OH0oaqAfZTszHw5XfbRVf7o9rzt7OSlPlP2ue3Vs58NVdnkX212997TgrVaWx7EjRtr/spCL6mT2yqi7Mw==
+"@strkfarm/sdk@2.0.0-staging.68":
+  version "2.0.0-staging.68"
+  resolved "https://registry.yarnpkg.com/@strkfarm/sdk/-/sdk-2.0.0-staging.68.tgz#fca4981a99e28705d41fb6b220c41714d67fce60"
+  integrity sha512-WBox5gW4VGSGmKebrssb/Gc7kOgXvCvj7U05JmqPlZ+d599TtVHSELAxmP5CiDbxAWDsbuhJ4ca7xYLqHPoFjg==
   dependencies:
     "@apollo/client" "3.11.8"
     "@avnu/avnu-sdk" "3.0.2"


### PR DESCRIPTION
Adds strkBTC/USDC, strkBTC/STRK, strkBTC/ETH and WBTC/strkBTC. strkBTC is only exposed by SDK 2.x, hence the bump.

SDK 2.0 now asserts depositTokens match the on-chain poolKey ordering (token0 < token1 by address), so depositTokens are sorted by address in strategies.atoms.tsx.

Also: guard AmountInput's max-amount simulation against an uninitialised tokenInfo (latent race only reachable post-bump), and source LOGOS from Global.getDefaultTokens() so the strkBTC icon is consistent everywhere.