### PR TITLE
perf: event-driven data fetching (replace constant polling)

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "wonka": "6.3.4"
   },
   "devDependencies": {
+    "@tanstack/react-query-devtools": "^5",
     "@types/lodash.debounce": "^4.0.9",
     "@types/node": "20",
     "@types/react": "^19",

--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -13,6 +13,7 @@ import { RpcProviderOptions, constants } from 'starknet';
 
 import { isMobile } from 'react-device-detect';
 import { StrategyDetailsProvider } from './providers/StrategyDetailsProvider';
+import QueryDevtools from '@/components/QueryDevtools';
 
 mixpanel.init('118f29da6a372f0ccb6f541079cad56b');
 
@@ -57,6 +58,7 @@ export default function Template({ children }: { children: React.ReactNode }) {
             <StrategyDetailsProvider />
           </React.Suspense>
         </div>
+        <QueryDevtools />
       </StarknetConfig>
     </JotaiProvider>
   );

--- a/src/components/QueryDevtools.tsx
+++ b/src/components/QueryDevtools.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { lazy, Suspense } from 'react';
+import { queryClient } from '@/utils/queryClient';
+
+// React Query DevTools — DEV ONLY.
+//
+// Two wrinkles handled here:
+//  1. Our query client lives in a Jotai atom (queryClientAtom on MY_STORE), not
+//     a React `QueryClientProvider`, so the devtools can't read it from context
+//     — we pass our shared `queryClient` explicitly via the `client` prop.
+//  2. The repo resolves two @tanstack/query-core versions (ours is 5.28.0; the
+//     devtools' react-query peer pulls 5.90.x), so the `QueryClient` types don't
+//     line up nominally. The devtools only call stable 5.x cache APIs at runtime,
+//     so the cast is safe.
+//
+// The dev-only `lazy` import sits in a branch that is statically false in
+// production, so the devtools bundle is tree-shaken out of prod builds.
+const ReactQueryDevtools =
+  process.env.NODE_ENV === 'development'
+    ? lazy(() =>
+        import('@tanstack/react-query-devtools').then((m) => ({
+          default: m.ReactQueryDevtools,
+        })),
+      )
+    : null;
+
+export default function QueryDevtools() {
+  if (!ReactQueryDevtools) return null;
+  return (
+    <Suspense fallback={null}>
+      {/* eslint-disable-next-line @typescript-eslint/no-explicit-any */}
+      <ReactQueryDevtools client={queryClient as any} initialIsOpen={false} />
+    </Suspense>
+  );
+}

--- a/src/store/balance.atoms.ts
+++ b/src/store/balance.atoms.ts
@@ -125,7 +125,10 @@ function getERC20BalanceAtom(token: TokenInfo | undefined) {
       queryFn: async ({ queryKey }: any): Promise<BalanceResult> => {
         return getERC20Balance(token, get(addressAtom));
       },
-      refetchInterval: 5000,
+      // No polling: balances refetch on mount (e.g. opening the deposit form),
+      // on account change (address is in the key) and on tx confirmation
+      // (queryClient.invalidateQueries in transactions.atom.ts).
+      staleTime: 0,
     };
   });
 }
@@ -133,11 +136,11 @@ function getERC20BalanceAtom(token: TokenInfo | undefined) {
 function getERC4626BalanceAtom(token: TokenInfo | undefined) {
   return atomWithQuery((get) => {
     return {
-      queryKey: ['getERC4626Balance', token?.token],
+      queryKey: ['getERC4626Balance', token?.token, get(addressAtom)],
       queryFn: async ({ queryKey }: any): Promise<BalanceResult> => {
         return getERC4626Balance(token, get(addressAtom));
       },
-      refetchInterval: 5000,
+      staleTime: 0,
     };
   });
 }
@@ -145,7 +148,7 @@ function getERC4626BalanceAtom(token: TokenInfo | undefined) {
 function getERC721PositionValueAtom(token: NFTInfo | undefined) {
   return atomWithQuery((get) => {
     return {
-      queryKey: ['getERC721PositionValue', token?.address],
+      queryKey: ['getERC721PositionValue', token?.address, get(addressAtom)],
       queryFn: async ({ queryKey }: any): Promise<BalanceResult> => {
         try {
           return await getERC721PositionValue(token, get(addressAtom));
@@ -153,7 +156,7 @@ function getERC721PositionValueAtom(token: NFTInfo | undefined) {
           return returnEmptyBal();
         }
       },
-      refetchInterval: 5000,
+      staleTime: 0,
     };
   });
 }

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,3 +1,10 @@
 import { createStore } from 'jotai';
+import { queryClientAtom } from 'jotai-tanstack-query';
+import { queryClient } from '@/utils/queryClient';
 
 export const MY_STORE = createStore();
+
+// Make every atomWithQuery use our configured client (staleTime / no
+// focus-refetch / event-driven invalidation) instead of the library's stock
+// default. Set at module init, before any query atom is mounted.
+MY_STORE.set(queryClientAtom, queryClient);

--- a/src/store/transactions.atom.ts
+++ b/src/store/transactions.atom.ts
@@ -13,6 +13,7 @@ import { atomWithQuery } from 'jotai-tanstack-query';
 import { gql } from '@apollo/client';
 import apolloClient from '@/utils/apolloClient';
 import { logErrorOnce } from '@/utils/errorLog';
+import { queryClient } from '@/utils/queryClient';
 import { Web3Number } from '@strkfarm/sdk';
 
 export interface StrategyTxProps {
@@ -413,6 +414,10 @@ async function waitForTransaction(
     nodeUrl: process.env.NEXT_PUBLIC_RPC_URL,
   });
   await isTxAccepted(tx.txHash);
+  // Tx confirmed on-chain → balances, positions, user stats and TVL have all
+  // changed. Refetch them now (event-driven) rather than relying on a polling
+  // timer to eventually pick the change up.
+  queryClient.invalidateQueries();
   const txs = await get(transactionsAtom);
   tx.status = 'success';
   txs.push(tx);

--- a/src/store/utils.atoms.ts
+++ b/src/store/utils.atoms.ts
@@ -53,7 +53,6 @@ export const userStatsAtom = atomWithQuery((get) => ({
     if (data.holdingsUSD !== 0 && !data.holdingsUSD) return null;
     return data;
   },
-  refetchInterval: 5000,
 }));
 
 export const userStrategyWiseTVLAtom = atomFamily((strategyId: string) => {
@@ -110,6 +109,10 @@ export const tokenPricesAtom = atomWithQuery(() => ({
     });
     return await Promise.all(tokenPrices);
   },
+  // Prices move slowly; a long staleTime stops them refetching constantly. This
+  // also breaks the fees cascade: getFeesHistoryAtom keys on the prices object,
+  // so a fresh prices fetch used to re-run 15 GraphQL + 15 RPC calls.
+  staleTime: 300_000,
 }));
 
 // export const strategyTVLAtom = atom((get) => {

--- a/src/strategies/IStrategy.ts
+++ b/src/strategies/IStrategy.ts
@@ -248,7 +248,10 @@ export class IStrategyProps<T> {
         queryFn: async ({ queryKey }: any): Promise<AmountsInfo> => {
           return this.getTVL();
         },
-        refetchInterval: 15000,
+        // Gentle poll for the strategy detail page (TVL drifts from other users'
+        // activity / rebalances); paused when the tab is hidden via the global
+        // refetchIntervalInBackground:false.
+        refetchInterval: 60000,
       };
     });
     this.balancesAtom = this.getBalancesAtom();

--- a/src/strategies/ekubo_cl_vault.ts
+++ b/src/strategies/ekubo_cl_vault.ts
@@ -294,7 +294,7 @@ export class EkuboClStrategy extends IStrategy<CLVaultStrategySettings> {
             return returnEmptyBal();
           }
         },
-        refetchInterval: 10000,
+        refetchInterval: 60000,
       };
     });
   };
@@ -338,7 +338,7 @@ export class EkuboClStrategy extends IStrategy<CLVaultStrategySettings> {
             tokenInfo: convertToV1TokenInfo(this.settings.quoteToken),
           };
         },
-        refetchInterval: 10000,
+        refetchInterval: 60000,
       };
     });
   };

--- a/src/utils/queryClient.ts
+++ b/src/utils/queryClient.ts
@@ -1,0 +1,25 @@
+import { QueryClient } from '@tanstack/query-core';
+
+// Single shared QueryClient for every `atomWithQuery` (wired into MY_STORE via
+// jotai-tanstack-query's `queryClientAtom` in src/store/index.ts).
+//
+// Defaults matter here: without them jotai-tanstack-query falls back to stock
+// TanStack defaults (staleTime 0 + refetchOnWindowFocus true), which made the
+// app refetch *everything* on every tab focus. We drive freshness off events
+// instead (mount, account change, tx confirmation — see queryClient
+// invalidation in transactions.atom.ts), so the global config is deliberately
+// quiet:
+//   - staleTime 60s: don't refetch data we fetched seconds ago
+//   - no refetch on window focus: focusing the tab shouldn't re-hit the chain
+//   - refetchIntervalInBackground false: pollers pause when the tab is hidden
+//   - retry 1: fail fast instead of hammering a failing endpoint
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60_000,
+      refetchOnWindowFocus: false,
+      refetchIntervalInBackground: false,
+      retry: 1,
+    },
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2135,6 +2135,18 @@
   resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.90.11.tgz#702e2b197a01481cff858045de1e17a634b718c6"
   integrity sha512-f9z/nXhCgWDF4lHqgIE30jxLe4sYv15QodfdPDKYAk7nAEjNcndy4dHz3ezhdUaR23BpWa4I2EH4/DZ0//Uf8A==
 
+"@tanstack/query-devtools@5.101.1":
+  version "5.101.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-devtools/-/query-devtools-5.101.1.tgz#89e666dcbcaa58cfb5d0ee0286b5aa9b103a1d3a"
+  integrity sha512-37RQ9U2PxlXQiv1era2t+uHgVhmiyvxqTMu30+KoVf0rufiucu6rpGRKFJk61Wh5OAZFKqCQd6lxTzFWfLZiuQ==
+
+"@tanstack/react-query-devtools@^5":
+  version "5.101.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query-devtools/-/react-query-devtools-5.101.1.tgz#d6d0c50d106dc60f48481cc7abd6461beb204a6a"
+  integrity sha512-OXFR9XKdEslraq3cpl3kCUeNvTIq/xGWEZiFZdn2bLB/q4WxSALMEDKYZ5yYjMQytsfnQxwQYqV4qtVEf0nuog==
+  dependencies:
+    "@tanstack/query-devtools" "5.101.1"
+
 "@tanstack/react-query@^5.25.0":
   version "5.90.11"
   resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.90.11.tgz#9e7669cda649ed119f70b6432b3932f19cbe1cb5"


### PR DESCRIPTION
Replaces blind time-based polling with event-driven refresh. Fresher where it matters (post-tx, account change), far fewer idle requests.

## Why
There was **no `QueryClient` config**, so every `atomWithQuery` inherited stock defaults (`staleTime:0` + `refetchOnWindowFocus:true`) — focusing the tab refetched everything. On top of that, balances + user stats polled every **5s**, TVL every 10–15s, none pausing when the tab was hidden. And nothing refreshed balances after a deposit/redeem **except** that 5s poll.

## Changes
- **Shared configured `QueryClient`** (`utils/queryClient.ts`), wired into `MY_STORE` via `queryClientAtom`. Defaults: `staleTime 60s`, `refetchOnWindowFocus:false`, `refetchIntervalInBackground:false`, `retry:1`.
- **Invalidate on tx confirm** — `waitForTransaction` calls `queryClient.invalidateQueries()` the moment a tx is accepted on-chain, so balances/positions/stats refresh immediately (fresher than the old poll).
- **Balances are now event-driven** — dropped the 5s `refetchInterval`; `staleTime:0` so they refetch on mount (opening the deposit form), on account change, and on tx confirm. Added `addressAtom` to the ERC4626/721 query keys (previously missing → wouldn't refetch on account switch).
- **User stats** — dropped the 5s poll (covered by mount + account change + tx invalidate).
- **Prices** — `staleTime 300s`; also breaks the fees cascade (fees GraphQL keyed on the prices object → used to re-run 15 GraphQL + 15 RPC on every price refetch).
- **Live TVL polls kept but slowed** 15s/10s → **60s** (the justified "watching the detail page" case; TVL drifts from other users), now paused when the tab is hidden.

## Verification
- `yarn typecheck` clean · `yarn lint:check` 0 errors · `yarn build` succeeds
- Runtime: home page makes 1×`/api/stats` + 1×`/api/strategies` and stays quiet over 16s (was polling before)

## Not runtime-tested
Post-tx invalidation and account-switch refetch are wired correctly per code but need a connected wallet + real tx to validate end-to-end — worth a quick check in your review/staging.