### PR TITLE
fix: tx history GraphQL 400 (indexer renamed txHash → tx_hash)

### DIFF
--- a/src/store/transactions.atom.ts
+++ b/src/store/transactions.atom.ts
@@ -298,7 +298,9 @@ async function getTxHistory(
             amount
             timestamp
             type
-            txHash
+            # indexer renamed this field to tx_hash; alias it back to txHash so
+            # the rest of the app keeps using txHash unchanged
+            txHash: tx_hash
             asset
           }
         }


### PR DESCRIPTION
## Problem
The user transaction-history list (strategy detail pages) silently fails — `findManyInvestment_flows` returns **HTTP 400** from the indexer (`api.troves.fi`). Affects prod (same indexer).

## Root cause
The indexer schema renamed `txHash` → `tx_hash`. Our query still selects `txHash`, so GraphQL validation fails:
> `Cannot query field "txHash" on type "Investment_flows". Did you mean "tx_hash"?` (`GRAPHQL_VALIDATION_FAILED`)

The other indexer queries are fine (verified against the live endpoint): `contractFeeEarnings`, `ekuboVaultFlows`, `findManyHarvests` all 200.

## Fix
Alias the field back in the query — `txHash: tx_hash` — so the response shape is unchanged and no downstream code touches are needed.

## Verification
- Live endpoint: corrected query returns `200` (was `400`).
- `yarn typecheck` clean.

Note: the earlier "Error fetching harvest data" in console is a *separate* issue (Yahoo price API rate-limiting), not GraphQL.