### PR TITLE
chore: remove unused vars/params

### DIFF
--- a/src/app/api/stats/route.ts
+++ b/src/app/api/stats/route.ts
@@ -20,7 +20,7 @@ export async function GET(_req: Request) {
 
   const strategies = getStrategies();
 
-  const values = strategies.map(async (strategy, index) => {
+  const values = strategies.map(async (strategy) => {
     if (strategy.isLive()) {
       let retry = 0;
       while (retry < 3) {

--- a/src/app/r/[referralCode]/route.ts
+++ b/src/app/r/[referralCode]/route.ts
@@ -10,7 +10,6 @@ export async function GET(req: Request, context: any) {
     },
   });
 
-  const origin = req.headers.get('origin');
   const host = req.headers.get('host'); // This gives y
   const protocol = req.headers.get('x-forwarded-proto') || 'http';
 

--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -27,7 +27,7 @@ export const CONNECTOR_NAMES = ['Braavos', 'Argent X', 'Argent (mobile)']; // 'A
 export default function Template({ children }: { children: React.ReactNode }) {
   const chains = [mainnet];
   const provider = jsonRpcProvider({
-    rpc: (chain) => {
+    rpc: () => {
       const args: RpcProviderOptions = {
         nodeUrl:
           'https://rpc.nethermind.io/mainnet-juno?apikey=t1HPjhplOyEQpxqVMhpwLGuwmOlbXN0XivWUiPAxIBs0kHVK',

--- a/src/components/AmountInput.tsx
+++ b/src/components/AmountInput.tsx
@@ -86,9 +86,7 @@ const AmountInput = forwardRef(
     }, [inputsInfo, inputInfo.rawAmount]);
 
     // Default token state
-    const [selectedMarket, setSelectedMarket] = useState<TokenInfoV2>(
-      props.tokenInfo,
-    );
+    const [selectedMarket] = useState<TokenInfoV2>(props.tokenInfo);
 
     useImperativeHandle(ref, () => ({
       reset: () => {

--- a/src/components/Deposit.tsx
+++ b/src/components/Deposit.tsx
@@ -20,7 +20,6 @@ import {
 } from '@strkfarm/sdk';
 import AmountInput, { AmountInputRef } from './AmountInput';
 import { addressAtom } from '@/store/claims.atoms';
-import { strategyByIdAtom } from '@/store/strategiesInfo.atoms';
 
 interface DepositProps {
   strategy: StrategyInfo<any>;
@@ -58,7 +57,7 @@ export type DepositAtomType = {
 };
 
 function getInputInfoAtoms() {
-  return [1, 2].map((i) => {
+  return [1, 2].map(() => {
     return atom<AmountInputInfo>({
       isMaxClicked: false,
       amount: Web3Number.fromWei('0', 0),
@@ -151,8 +150,6 @@ function InternalDeposit(props: DepositProps) {
   const inputRefs = [inputRef1, inputRef2];
   const inputErrors = [inputError1, inputError2];
   const setInputErrors = [setInputError1, setInputError2];
-
-  const strategyDetails = useAtomValue(strategyByIdAtom(props.strategy.id));
 
   // since we use a separate jotai provider,
   // need to set this again here

--- a/src/components/HarvestTime.tsx
+++ b/src/components/HarvestTime.tsx
@@ -14,7 +14,7 @@ interface HarvestTimeProps {
   balData: any;
 }
 
-const HarvestTime: React.FC<HarvestTimeProps> = ({ strategy, balData }) => {
+const HarvestTime: React.FC<HarvestTimeProps> = ({ strategy }) => {
   const { address } = useAccount();
   const holdingToken: any = strategy.holdingTokens[0];
   const contractAddress = holdingToken.address || holdingToken.token || '';

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -153,8 +153,8 @@ interface NavbarProps {
   forceShowConnect?: boolean;
 }
 
-export default function Navbar(props: NavbarProps) {
-  const { address, connector, account } = useAccount();
+export default function Navbar(_props: NavbarProps) {
+  const { address, connector } = useAccount();
   const { disconnectAsync } = useDisconnect();
   const setAddress = useSetAtom(addressAtom);
   const { data: starkProfile } = useStarkProfile({
@@ -163,7 +163,7 @@ export default function Navbar(props: NavbarProps) {
   });
   const { connect: connectSnReact } = useConnect();
 
-  const [lastWallet, setLastWallet] = useAtom(lastWalletAtom);
+  const [, setLastWallet] = useAtom(lastWalletAtom);
 
   const getTokenBalance = async (token: string, address: string) => {
     const tokenInfo = getTokenInfoFromName(token);

--- a/src/components/Redeem.tsx
+++ b/src/components/Redeem.tsx
@@ -60,7 +60,7 @@ type RedeemAtomType = {
 };
 
 function getInputInfoAtoms() {
-  return [1, 2].map((i) => {
+  return [1, 2].map(() => {
     return atom<AmountInputInfo>({
       isMaxClicked: false,
       amount: Web3Number.fromWei('0', 0),
@@ -216,7 +216,6 @@ function InternalRedeem(props: RedeemProps) {
   const maxAmount: MyNumber = useMemo(() => {
     if (!selectedToken) return MyNumber.fromZero();
 
-    const currentTVL = Number(tvlInfo.data?.amounts[0].amount.toFixed(6) || 0);
     const maxAllowed = Number(balance.toEtherToFixedDecimals(8));
 
     const adjustedMaxAllowed = MyNumber.fromEther(
@@ -544,8 +543,6 @@ function InternalRedeem(props: RedeemProps) {
     JSON.stringify(firstInputInfo),
     isMaxClicked,
   ]);
-
-  const isRedeem = useMemo(() => props.buttonText === 'Redeem', [props]);
 
   const [loadingInvestmentSummary, setLoadingInvestmentSummary] =
     useState(false);

--- a/src/components/ui/simple-tooltip.tsx
+++ b/src/components/ui/simple-tooltip.tsx
@@ -15,7 +15,6 @@ export function SimpleTooltip({
   label,
   children,
   className,
-  hasArrow,
 }: {
   label: React.ReactNode;
   children: React.ReactNode;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { constants, RpcProvider } from 'starknet';
+import { RpcProvider } from 'starknet';
 import { Global } from '@strkfarm/sdk';
 import { NFTInfo, TokenInfo } from './strategies/IStrategy';
 import { standariseAddress } from './utils';
@@ -252,13 +252,6 @@ export const NFTS: NFTInfo[] = [
     },
   },
 ];
-
-function getNetwork(): constants.StarknetChainId {
-  if (process.env.NEXT_PUBLIC_NETWORK === 'sepolia') {
-    return constants.StarknetChainId.SN_SEPOLIA;
-  }
-  return constants.StarknetChainId.SN_MAIN;
-}
 
 export const provider = new RpcProvider({
   nodeUrl: process.env.NEXT_PUBLIC_RPC_URL,

--- a/src/store/IDapp.store.ts
+++ b/src/store/IDapp.store.ts
@@ -8,7 +8,7 @@ export class IDapp<BaseAPYT> {
   logo: string = '';
 
   incentiveDataKey: string = '';
-  _computePoolsInfo(data: any): PoolInfo[] {
+  _computePoolsInfo(_data: any): PoolInfo[] {
     throw new Error('not implemented: _computePoolsInfo');
   }
 
@@ -34,8 +34,8 @@ export class IDapp<BaseAPYT> {
   }
 
   getBaseAPY(
-    p: PoolInfo,
-    data: AtomWithQueryResult<BaseAPYT, Error>,
+    _p: PoolInfo,
+    _data: AtomWithQueryResult<BaseAPYT, Error>,
   ): {
     baseAPY: number | 'Err';
     splitApr: APRSplit | null;

--- a/src/store/balance.atoms.ts
+++ b/src/store/balance.atoms.ts
@@ -122,7 +122,7 @@ function getERC20BalanceAtom(token: TokenInfo | undefined) {
   return atomWithQuery((get) => {
     return {
       queryKey: ['getERC20Balance', token?.token, get(addressAtom)],
-      queryFn: async ({ queryKey }: any): Promise<BalanceResult> => {
+      queryFn: async (): Promise<BalanceResult> => {
         return getERC20Balance(token, get(addressAtom));
       },
       // No polling: balances refetch on mount (e.g. opening the deposit form),
@@ -137,7 +137,7 @@ function getERC4626BalanceAtom(token: TokenInfo | undefined) {
   return atomWithQuery((get) => {
     return {
       queryKey: ['getERC4626Balance', token?.token, get(addressAtom)],
-      queryFn: async ({ queryKey }: any): Promise<BalanceResult> => {
+      queryFn: async (): Promise<BalanceResult> => {
         return getERC4626Balance(token, get(addressAtom));
       },
       staleTime: 0,
@@ -149,7 +149,7 @@ function getERC721PositionValueAtom(token: NFTInfo | undefined) {
   return atomWithQuery((get) => {
     return {
       queryKey: ['getERC721PositionValue', token?.address, get(addressAtom)],
-      queryFn: async ({ queryKey }: any): Promise<BalanceResult> => {
+      queryFn: async (): Promise<BalanceResult> => {
         try {
           return await getERC721PositionValue(token, get(addressAtom));
         } catch (e) {
@@ -161,28 +161,9 @@ function getERC721PositionValueAtom(token: NFTInfo | undefined) {
   });
 }
 
-async function getBalance(
-  token: TokenInfo | NFTInfo | undefined,
-  address: string,
-) {
-  if (token) {
-    if (Object.prototype.hasOwnProperty.call(token, 'isERC4626')) {
-      const _token = <TokenInfo>token;
-      if (_token.isERC4626) return getERC4626Balance(_token, address);
-    } else {
-      const _token = <NFTInfo>token;
-      const isNFT = NFTS.find((nft) => nft.address === _token.address);
-      if (isNFT) return getERC721PositionValue(_token, address);
-    }
-    return getERC20Balance(<TokenInfo>token, address);
-  }
-
-  return returnEmptyBal();
-}
-
 export function getBalanceAtom(
   token: TokenInfo | NFTInfo | undefined,
-  enabledAtom: Atom<boolean>,
+  _enabledAtom: Atom<boolean>,
 ) {
   if (token) {
     if (Object.prototype.hasOwnProperty.call(token, 'isERC4626')) {
@@ -199,10 +180,10 @@ export function getBalanceAtom(
   return getERC20BalanceAtom(<TokenInfo>token);
 }
 
-export const DUMMY_BAL_ATOM = atomWithQuery((get) => {
+export const DUMMY_BAL_ATOM = atomWithQuery(() => {
   return {
     queryKey: ['DUMMY_BAL_ATOM'],
-    queryFn: async ({ queryKey }: any): Promise<BalanceResult> => {
+    queryFn: async (): Promise<BalanceResult> => {
       return returnEmptyBal();
     },
     refetchInterval: 100000000,

--- a/src/store/harvest.atom.ts
+++ b/src/store/harvest.atom.ts
@@ -71,7 +71,7 @@ async function getHarvestData(
 }
 
 export const HarvestTimeAtom = (contract: string) =>
-  atomWithQuery((get) => ({
+  atomWithQuery(() => ({
     queryKey: ['harvest_data', contract],
     queryFn: async () => {
       const result = await getHarvestData(contract);

--- a/src/store/strkfarm.atoms.ts
+++ b/src/store/strkfarm.atoms.ts
@@ -152,11 +152,9 @@ class STRKFarm extends IDapp<STRKFarmStrategyAPIResult> {
   }
 }
 
-export const STRKFarmBaseAPYsAtom = atomWithQuery((get) => ({
+export const STRKFarmBaseAPYsAtom = atomWithQuery(() => ({
   queryKey: ['strkfarm_base_aprs'],
-  queryFn: async ({
-    queryKey,
-  }): Promise<{
+  queryFn: async (): Promise<{
     strategies: STRKFarmStrategyAPIResult[];
   }> => {
     const response = await fetch(`${CONSTANTS.STRKFarm.BASE_APR_API}`);

--- a/src/store/transactions.atom.ts
+++ b/src/store/transactions.atom.ts
@@ -331,7 +331,7 @@ export const TxHistoryAtom = (contract: string, owner: string) =>
   atomWithQuery((get) => ({
     // balData just to trigger a refetch
     queryKey: ['tx_history', contract, owner, JSON.stringify(get(newTxsAtom))],
-    queryFn: async ({ queryKey }: any): Promise<TxHistory> => {
+    queryFn: async (): Promise<TxHistory> => {
       // const [, { contract, owner }] = queryKey;
       const res = await getTxHistory(contract, owner);
 
@@ -412,9 +412,6 @@ async function waitForTransaction(
   get: Getter,
   set: Setter,
 ) {
-  const provider = new RpcProvider({
-    nodeUrl: process.env.NEXT_PUBLIC_RPC_URL,
-  });
   await isTxAccepted(tx.txHash);
   // Tx confirmed on-chain → balances, positions, user stats and TVL have all
   // changed. Refetch them now (event-driven) rather than relying on a polling

--- a/src/store/utils.atoms.ts
+++ b/src/store/utils.atoms.ts
@@ -12,7 +12,7 @@ interface DAppStats {
   tvl: number;
 }
 
-export const dAppStatsAtom = atomWithQuery((get) => ({
+export const dAppStatsAtom = atomWithQuery(() => ({
   queryKey: ['stats'],
   queryFn: async (): Promise<DAppStats> => {
     const res = await fetchWithRetry(

--- a/src/strategies/IStrategy.ts
+++ b/src/strategies/IStrategy.ts
@@ -194,13 +194,13 @@ export class IStrategyProps<T> {
   }
 
   depositMethods = async (
-    inputs: DepositActionInputs,
+    _inputs: DepositActionInputs,
   ): Promise<IStrategyActionHook[]> => {
     return [];
   };
 
   withdrawMethods = async (
-    inputs: WithdrawActionInputs,
+    _inputs: WithdrawActionInputs,
   ): Promise<IStrategyActionHook[]> => {
     return [];
   };
@@ -209,7 +209,7 @@ export class IStrategyProps<T> {
     throw new Error('getTVL: Not implemented');
   };
 
-  getUserTVL = async (user: string): Promise<AmountsInfo> => {
+  getUserTVL = async (_user: string): Promise<AmountsInfo> => {
     throw new Error('getTVL: Not implemented');
   };
 
@@ -242,10 +242,10 @@ export class IStrategyProps<T> {
     this.liveStatus = liveStatus;
     this.settings = settings;
     this.metadata = metadata;
-    this.tvlAtom = atomWithQuery((get) => {
+    this.tvlAtom = atomWithQuery(() => {
       return {
         queryKey: ['tvl', this.id],
-        queryFn: async ({ queryKey }: any): Promise<AmountsInfo> => {
+        queryFn: async (): Promise<AmountsInfo> => {
           return this.getTVL();
         },
         // Gentle poll for the strategy detail page (TVL drifts from other users'

--- a/src/strategies/ekubo_cl_vault.ts
+++ b/src/strategies/ekubo_cl_vault.ts
@@ -157,7 +157,7 @@ export class EkuboClStrategy extends IStrategy<CLVaultStrategySettings> {
   }
 
   depositMethods = async (inputs: DepositActionInputs) => {
-    const { amount, address, provider, amount2 } = inputs;
+    const { amount, address, amount2 } = inputs;
     const token0Info = getTokenInfoFromName(
       this.metadata.depositTokens[0].symbol,
     );
@@ -198,7 +198,7 @@ export class EkuboClStrategy extends IStrategy<CLVaultStrategySettings> {
   withdrawMethods = async (
     inputs: WithdrawActionInputs,
   ): Promise<IStrategyActionHook[]> => {
-    const { amount, address, provider, amount2 } = inputs;
+    const { amount, address, amount2 } = inputs;
     const output = {
       calls: [],
       amounts: [
@@ -246,7 +246,7 @@ export class EkuboClStrategy extends IStrategy<CLVaultStrategySettings> {
     ];
   };
 
-  async solve(pools: PoolInfo[], amount: string) {
+  async solve(_pools: PoolInfo[], _amount: string) {
     const yieldInfo = await this.clVault.netAPY('latest', 16000);
     this.netYield = yieldInfo;
     this.leverage = 1;
@@ -269,7 +269,7 @@ export class EkuboClStrategy extends IStrategy<CLVaultStrategySettings> {
           get(addressAtom),
           JSON.stringify(get(holdingBalAtom).data),
         ],
-        queryFn: async ({ queryKey }: any): Promise<BalanceResult> => {
+        queryFn: async (): Promise<BalanceResult> => {
           try {
             const bal = get(holdingBalAtom);
             if (!bal.data) {
@@ -309,7 +309,7 @@ export class EkuboClStrategy extends IStrategy<CLVaultStrategySettings> {
           ),
           get(addressAtom),
         ],
-        queryFn: async ({ queryKey }: any): Promise<BalanceResult> => {
+        queryFn: async (): Promise<BalanceResult> => {
           const bal1 = get(this.balanceAtoms[0]);
           const bal2 = get(this.balanceAtoms[1]);
           if (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,11 +1,6 @@
 import { Call, num } from 'starknet';
 import { TOKENS } from './constants';
-import toast from 'react-hot-toast';
-import {
-  AmountsInfo,
-  IStrategyActionHook,
-  TokenInfo,
-} from './strategies/IStrategy';
+import { IStrategyActionHook, TokenInfo } from './strategies/IStrategy';
 import {
   ContractAddr,
   TokenInfo as TokenInfoV2,
@@ -21,14 +16,6 @@ import { Atom, atom } from 'jotai';
 import { AtomWithQueryResult } from 'jotai-tanstack-query';
 import assert from 'assert';
 import MyNumber from './utils/MyNumber';
-
-function getUniqueStrings(arr: Array<string>) {
-  const _arr: string[] = [];
-  arr.forEach((item) => {
-    if (!_arr.includes(item)) _arr.push(item);
-  });
-  return _arr;
-}
 
 function getUnique<T>(arr: Array<T>, uniqueField: string) {
   const _arr: T[] = [];
@@ -146,15 +133,7 @@ export function formatTimediff(endTime: Date) {
   };
 }
 
-function copyReferralLink(refCode: string) {
-  navigator.clipboard.writeText(getReferralUrl(refCode));
-
-  toast.success('Referral link copied to clipboard', {
-    position: 'bottom-right',
-  });
-}
-
-export async function getPrice(tokenInfo: MyMultiTokenInfo, source?: string) {
+export async function getPrice(tokenInfo: MyMultiTokenInfo, _source?: string) {
   try {
     const price = await getPriceFromMyAPI(tokenInfo);
     if (isNaN(price)) {
@@ -304,31 +283,6 @@ export function convertToMyNumber(amount: MyWeb3Number): MyNumber {
   return new MyNumber(amount.toWei(), amount.decimals);
 }
 
-function ZeroAmountsInfo(tokens: MyMultiTokenInfo[]): AmountsInfo {
-  const res: AmountsInfo = {
-    usdValue: 0,
-    amounts: [],
-  };
-  for (let i = 0; i < tokens.length; i++) {
-    const token: any = tokens[i];
-    const isTokenInfoV1 = token.token !== undefined;
-    res.amounts.push({
-      amount: Web3Number.fromWei('0', tokens[i].decimals),
-      tokenInfo: isTokenInfoV1
-        ? convertToV2TokenInfo(TOKENS[i])
-        : (tokens[i] as TokenInfoV2),
-      usdValue: 0,
-    });
-  }
-  return res;
-}
-
-function DummyStrategyActionHook(
-  tokens: MyMultiTokenInfo[],
-): IStrategyActionHook {
-  return buildStrategyActionHook([], tokens, null, true);
-}
-
 export function buildStrategyActionHook(
   calls: Call[],
   tokens: MyMultiTokenInfo[],
@@ -366,14 +320,6 @@ export function buildStrategyActionHook(
       };
     }),
   };
-}
-
-function formatUSD(amount: number) {
-  return amount > 1000000
-    ? `${(amount / 1000000).toFixed(2)}M`
-    : amount > 1000
-      ? amount.toFixed(0)
-      : amount.toFixed(2);
 }
 
 export function formatTokenBalance(amount: MyNumber, decimals: number = 0) {

--- a/src/utils/MyNumber.ts
+++ b/src/utils/MyNumber.ts
@@ -115,7 +115,7 @@ export default class MyNumber {
     );
   }
 
-  [customInspectSymbol](depth: any, inspectOptions: any, inspect: any) {
+  [customInspectSymbol](_depth: any, _inspectOptions: any, _inspect: any) {
     return JSON.stringify({ raw: this.toString(), decimals: this.decimals });
   }
 }

--- a/src/utils/fetchWithRetry.ts
+++ b/src/utils/fetchWithRetry.ts
@@ -4,7 +4,7 @@ import { logErrorOnce } from '@/utils/errorLog';
 async function fetchWithRetry(
   url: string,
   options: any = {},
-  errorToast: string = 'Failed to fetch',
+  _errorToast: string = 'Failed to fetch',
 ): Promise<Response | null> {
   const maxRetries = 3;
   const baseDelay = 1000;


### PR DESCRIPTION
Clears all 52 `unused-imports/no-unused-vars` warnings. Three handling types, chosen per-site:

- **Deleted dead code** — 6 unreferenced local functions (`getUniqueStrings`, `copyReferralLink`, `ZeroAmountsInfo`, `DummyStrategyActionHook`, `formatUSD`, `getNetwork`, plus a dead `getBalance`) and several unused local consts (`origin`, `currentTVL`, `isRedeem`, `strategyDetails`, an unused `RpcProvider`). Removed the imports those orphaned.
- **Simplified callbacks** — dropped unused params/destructure members: `({ queryKey }: any)` → `()` (9 queryFns), `(get)` → `()` (5 atoms), unused `.map((i)=>)`/`(chain)`/`index`, unused `account`/`provider`/`balData`/`hasArrow` destructure members, unused setters/values.
- **`_`-prefixed** signature/contract/protocol params that callers/overrides depend on (base `IStrategy`/`IDapp` stubs, `solve`, Node's `customInspect`, `errorToast`, `getPrice` `source`, `Navbar` props, `getBalanceAtom` `enabledAtom`).

Every deletion was grep-verified to have zero references first.

## Result
- Warnings **116 → 66** (unused-vars 52 → 0). Net ~-90 lines.
- Remaining are the deliberately-untouched `react-hooks/exhaustive-deps` (49) + `no-img-element` (14) + 2 `!= undefined` idioms.

## Verification
- `yarn typecheck` clean · `yarn build` succeeds · `yarn lint` 0 errors.
- Runtime (prod build): home grid 22 rows + a strategy detail page (Deposit/Redeem/Harvest/APY) render correctly — the touched core files (IStrategy, ekubo, balance.atoms, Deposit, Redeem, Navbar) all work.