### PR TITLE
fix: dead nethermind RPC causing prod crash + wallet reconnect on refresh

### DIFF
--- a/src/app/api/price/[name]/route.ts
+++ b/src/app/api/price/[name]/route.ts
@@ -1,0 +1,35 @@
+import { getMainnetConfig, Global, PricerFromApi } from '@strkfarm/sdk';
+import { NextResponse } from 'next/server';
+
+export const revalidate = 300; // 5 mins
+export const dynamic = 'force-dynamic';
+
+export async function GET(_req: Request, context: any) {
+  try {
+    const params = await context.params;
+    const tokenName = params.name;
+
+    if (!tokenName) {
+      throw new Error('Invalid token');
+    }
+
+    const rpcUrl = process.env.RPC_URL || process.env.NEXT_PUBLIC_RPC_URL;
+    const config = getMainnetConfig(rpcUrl, 'latest');
+    const pricer = new PricerFromApi(config, Global.getDefaultTokens());
+    const priceInfo = await pricer.getPrice(tokenName);
+
+    const resp = NextResponse.json({
+      price: priceInfo.price,
+      timestamp: priceInfo.timestamp,
+      name: tokenName,
+    });
+    resp.headers.set(
+      'Cache-Control',
+      `s-maxage=${revalidate}, stale-while-revalidate=120`,
+    );
+    return resp;
+  } catch (err) {
+    console.error('Error /api/price/:name', err);
+    return NextResponse.json({}, { status: 500 });
+  }
+}

--- a/src/app/template.tsx
+++ b/src/app/template.tsx
@@ -29,8 +29,7 @@ export default function Template({ children }: { children: React.ReactNode }) {
   const provider = jsonRpcProvider({
     rpc: () => {
       const args: RpcProviderOptions = {
-        nodeUrl:
-          'https://rpc.nethermind.io/mainnet-juno?apikey=t1HPjhplOyEQpxqVMhpwLGuwmOlbXN0XivWUiPAxIBs0kHVK',
+        nodeUrl: process.env.NEXT_PUBLIC_RPC_URL,
         chainId: constants.StarknetChainId.SN_MAIN,
       };
       return args;
@@ -44,6 +43,7 @@ export default function Template({ children }: { children: React.ReactNode }) {
         chains={chains}
         provider={provider}
         connectors={getConnectors(isMobile)}
+        autoConnect
       >
         <div className="flex min-h-screen bg-[#171717]">
           <React.Suspense>

--- a/src/strategies/IStrategy.ts
+++ b/src/strategies/IStrategy.ts
@@ -274,14 +274,16 @@ export class IStrategyProps<T> {
     quoteToken: MyTokenInfo,
     source: string,
   ): Promise<MyWeb3Number> {
-    const valuesProm = amounts.map((amount) => {
-      return this.getValueInQuoteToken(
-        convertToV2Web3Number(amount.amount),
-        convertToV2TokenInfo(amount.tokenInfo),
-        quoteToken,
-        source,
-      );
-    });
+    const valuesProm = amounts
+      .filter((amount) => Boolean(amount?.tokenInfo))
+      .map((amount) => {
+        return this.getValueInQuoteToken(
+          convertToV2Web3Number(amount.amount),
+          convertToV2TokenInfo(amount.tokenInfo),
+          quoteToken,
+          source,
+        );
+      });
     const values = await Promise.all(valuesProm);
     const total = values.reduce(
       (acc, amount) => {


### PR DESCRIPTION
## Problem
Prod (`/strategy/*`) threw a client-side "Application error" when a wallet holding pool tokens was connected. Console showed `ERR_NAME_NOT_RESOLVED` for `rpc.nethermind.io`, a null-token crash in `computeSummaryValue`, an uncaught `Token not found`, and 404s on `/api/price/<token>`.

## Root causes
1. **Dead RPC**: `rpc.nethermind.io` is decommissioned (no longer resolves). `template.tsx` was the only place still hardcoding it — as the `@starknet-react` `StarknetConfig` provider, which backs the wallet account and every `useContractRead`/`useBalance` hook. The rest of the app already uses `NEXT_PUBLIC_RPC_URL` (Alchemy). Failed reads returned null `tokenInfo`, crashing `computeSummaryValue` and taking down the page.
2. **Deleted price route**: `/api/price/[name]` was removed in aa08b4f ("use prices from strkfarm api") but its callers (`utils.ts` getPrice, `api/lib.ts` rewards) still fetch it → 404. Client falls back to Coinbase (noisy); server-side rewards calc has no fallback and breaks.

## Changes
- **template.tsx**: provider `nodeUrl` → `process.env.NEXT_PUBLIC_RPC_URL` (matches the rest of the app).
- **template.tsx**: add `autoConnect` to `StarknetConfig` so a connected wallet is restored on refresh.
- **IStrategy.ts**: `computeSummaryValue` filters out null `tokenInfo` entries so a single failed read can't crash the whole strategy page.
- **api/price/[name]/route.ts**: recreated without Redis using `PricerFromApi`, returning `{ price, timestamp }` as before.

## Deploy note
`NEXT_PUBLIC_RPC_URL` is inlined at **build time** — the rebuild must run with it in scope.

## Out of scope
Yahoo Finance `Too Many Requests` on harvest data (non-fatal, separate fix).