### PR TITLE
fix: prevent 'Token not found' crash on strategy page for wallets with positions

### DIFF
--- a/src/app/strategy/[strategyId]/_components/Strategy.tsx
+++ b/src/app/strategy/[strategyId]/_components/Strategy.tsx
@@ -10,7 +10,7 @@ import { DUMMY_BAL_ATOM, returnEmptyBal } from '@/store/balance.atoms';
 import { addressAtom } from '@/store/claims.atoms';
 import { strategiesAtom, StrategyInfo } from '@/store/strategies.atoms';
 import { TxHistoryAtom } from '@/store/transactions.atom';
-import { formatTokenBalance, getTokenInfoFromAddr } from '@/utils';
+import { formatTokenBalance, getTokenInfoFromAddrOrNull } from '@/utils';
 import MyNumber from '@/utils/MyNumber';
 import { StrategyParams } from '../page';
 import FlowChart from './FlowChart';
@@ -89,7 +89,7 @@ const Strategy = ({ params }: StrategyParams) => {
   const [profit, setProfit] = useState(0);
   const computeProfit = useCallback(() => {
     if (!txHistory.findManyInvestment_flows.length) return 0;
-    const tokenInfo = getTokenInfoFromAddr(
+    const tokenInfo = getTokenInfoFromAddrOrNull(
       txHistory.findManyInvestment_flows[0].asset,
     );
     if (!tokenInfo) return 0;

--- a/src/store/balance.atoms.ts
+++ b/src/store/balance.atoms.ts
@@ -10,7 +10,7 @@ import DeltaNeutralAbi from '@/abi/deltraNeutral.abi.json';
 import DeltaNeutralAbi2 from '@/abi/deltaNeutral.2.abi.json';
 import { Atom } from 'jotai';
 import {
-  getTokenInfoFromAddr,
+  getTokenInfoFromAddrOrNull,
   getTokenInfoFromName,
   standariseAddress,
 } from '@/utils';
@@ -70,7 +70,9 @@ async function getERC4626Balance(
   ]);
 
   const asset = await erc4626Contract.call('asset', []);
-  const assetInfo = getTokenInfoFromAddr(standariseAddress(asset as string));
+  const assetInfo = getTokenInfoFromAddrOrNull(
+    standariseAddress(asset as string),
+  );
   if (!assetInfo) {
     throw new Error('ERC4626: Asset not found');
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,14 +59,13 @@ export function standariseAddress(address: string | bigint) {
   return a;
 }
 
-export function getTokenInfoFromAddr(tokenAddr: string) {
-  const info = TOKENS.find(
+// Returns undefined when the address isn't a known token, so callers in
+// render/effect paths can guard instead of crashing the React tree on an
+// unknown asset (e.g. a vault/LP token not in TOKENS).
+export function getTokenInfoFromAddrOrNull(tokenAddr: string) {
+  return TOKENS.find(
     (t) => standariseAddress(t.token) === standariseAddress(tokenAddr),
   );
-  if (!info) {
-    throw new Error('Token not found');
-  }
-  return info;
 }
 
 export function getTokenInfoFromName(tokenName: string) {


### PR DESCRIPTION
## Problem
After connecting a wallet that holds positions, the strategy page for an **ekubo CL (dual-token) vault** (e.g. `/strategy/ekubo_cl_usdceth`) crashed with `Uncaught Error: Token not found` → "Application error". **Separate from the dead-RPC fix in #64** — it persists with a working RPC.

## Root cause (verified against the live indexer)
`Strategy.tsx` `computeProfit` looks up the first investment-flow asset:
```js
const tokenInfo = getTokenInfoFromAddr(txHistory.findManyInvestment_flows[0].asset);
if (!tokenInfo) return 0;  // dead code — the line above THROWS instead of returning falsy
```
The indexer records **`asset: ""` (empty string) for every flow of ekubo CL dual-token vaults** (confirmed: 57/57 flows for `ekubo_cl_usdceth` are empty; same for WBTC/ETH, ETH/USDC.e). Single-token vaults record a real address (e.g. ETH), so they never crashed.

`getTokenInfoFromAddr("")` → `standariseAddress("")` normalises empty to `0x0` → matches no token in `TOKENS` → **throws** → the throw escapes `computeProfit`'s `useEffect` and crashes the React tree. Only happens when the wallet holds positions (flows are non-empty).

## Fix
- Add non-throwing `getTokenInfoFromAddrOrNull` (returns `undefined` for unknown/empty addresses).
- Use it in `Strategy.tsx` (computeProfit) and `balance.atoms.ts` (ERC4626 asset lookup) — both already had `if (!info)` guards that were dead because the old function threw first.
- Drop the now-unused throwing `getTokenInfoFromAddr`.

## Result / scope
Page loads instead of crashing. For CL vaults, PnL stays 0/unshown — correct-by-necessity, since the indexer doesn't populate `asset` and the single-token profit math can't represent a dual-token position. **Accurate CL-vault PnL is out of scope** and needs an indexer-side fix (populate `asset`) + dual-token profit logic.