### PR TITLE
fix: /api/stats 500 — price server-side via strkfarm pricer instead of app.troves.fi hop

### DIFF
--- a/src/app/api/price/[name]/route.ts
+++ b/src/app/api/price/[name]/route.ts
@@ -1,4 +1,4 @@
-import { getMainnetConfig, Global, PricerFromApi } from '@strkfarm/sdk';
+import { getServerPrice } from '@/utils/serverPricer';
 import { NextResponse } from 'next/server';
 
 export const revalidate = 300; // 5 mins
@@ -13,10 +13,7 @@ export async function GET(_req: Request, context: any) {
       throw new Error('Invalid token');
     }
 
-    const rpcUrl = process.env.RPC_URL || process.env.NEXT_PUBLIC_RPC_URL;
-    const config = getMainnetConfig(rpcUrl, 'latest');
-    const pricer = new PricerFromApi(config, Global.getDefaultTokens());
-    const priceInfo = await pricer.getPrice(tokenName);
+    const priceInfo = await getServerPrice(tokenName);
 
     const resp = NextResponse.json({
       price: priceInfo.price,

--- a/src/app/api/stats/[address]/route.ts
+++ b/src/app/api/stats/[address]/route.ts
@@ -20,40 +20,46 @@ export async function GET(_req: Request, context: any) {
 
   const strategies = getStrategies();
   const values: Promise<StrategyWise>[] = strategies.map(async (strategy) => {
-    if (strategy.isLive()) {
-      const balanceInfo: AmountsInfo = await strategy.getUserTVL(pAddr);
-      if (balanceInfo.amounts.length === 1) {
+    try {
+      if (strategy.isLive()) {
+        const balanceInfo: AmountsInfo = await strategy.getUserTVL(pAddr);
+        if (balanceInfo.amounts.length === 1) {
+          return {
+            id: strategy.id,
+            usdValue: balanceInfo.usdValue,
+            holdings: [
+              {
+                tokenInfo: balanceInfo.amounts[0].tokenInfo,
+                amount: balanceInfo.amounts[0].amount,
+                usdValue: balanceInfo.amounts[0].usdValue,
+              },
+            ],
+          };
+        }
+        const summary = await strategy.computeSummaryValue(
+          balanceInfo.amounts.map((a) => ({
+            tokenInfo: a.tokenInfo,
+            amount: a.amount,
+          })),
+          strategy.settings.quoteToken,
+          'stats[address]',
+        );
         return {
           id: strategy.id,
           usdValue: balanceInfo.usdValue,
           holdings: [
             {
-              tokenInfo: balanceInfo.amounts[0].tokenInfo,
-              amount: balanceInfo.amounts[0].amount,
-              usdValue: balanceInfo.amounts[0].usdValue,
+              tokenInfo: strategy.settings.quoteToken,
+              amount: summary,
+              usdValue: balanceInfo.usdValue,
             },
           ],
         };
       }
-      const summary = await strategy.computeSummaryValue(
-        balanceInfo.amounts.map((a) => ({
-          tokenInfo: a.tokenInfo,
-          amount: a.amount,
-        })),
-        strategy.settings.quoteToken,
-        'stats[address]',
-      );
-      return {
-        id: strategy.id,
-        usdValue: balanceInfo.usdValue,
-        holdings: [
-          {
-            tokenInfo: strategy.settings.quoteToken,
-            amount: summary,
-            usdValue: balanceInfo.usdValue,
-          },
-        ],
-      };
+    } catch (e) {
+      // A single strategy failing (e.g. a price lookup) must not 500 the whole
+      // portfolio endpoint; log it and return zero holdings for that strategy.
+      console.error(`[api/stats] strategy ${strategy.id} failed:`, e);
     }
 
     return {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -183,15 +183,28 @@ export function getHosturl() {
 }
 
 async function getPriceFromMyAPI(tokenInfo: MyMultiTokenInfo) {
-  const endpoint = getEndpoint();
-  const url = `${endpoint}/api/price/${convertToV2TokenInfo(tokenInfo).symbol}`;
-  const priceInfoRes = await fetch(url);
-  if (!priceInfoRes.ok) {
-    // Non-OK responses are HTML error pages; don't let .json() throw a noisy
-    // SyntaxError — surface a clean error so the caller falls back cleanly.
-    throw new Error(`price api ${priceInfoRes.status} for ${tokenInfo.name}`);
+  const symbol = convertToV2TokenInfo(tokenInfo).symbol;
+
+  let priceInfo: { price: number | string; timestamp: string | Date };
+  if (typeof window === 'undefined') {
+    // Server-side: price directly via the pricer instead of HTTP-hopping
+    // through `${getEndpoint()}/api/price`. The endpoint falls back to a
+    // foreign app (app.troves.fi) when HOSTNAME is unset, which returns a stub
+    // and breaks server-side pricing (e.g. /api/stats). Dynamic import keeps
+    // the SDK pricer out of the client bundle.
+    const { getServerPrice } = await import('./utils/serverPricer');
+    priceInfo = await getServerPrice(symbol);
+  } else {
+    const url = `${getEndpoint()}/api/price/${symbol}`;
+    const priceInfoRes = await fetch(url);
+    if (!priceInfoRes.ok) {
+      // Non-OK responses are HTML error pages; don't let .json() throw a noisy
+      // SyntaxError — surface a clean error so the caller falls back cleanly.
+      throw new Error(`price api ${priceInfoRes.status} for ${tokenInfo.name}`);
+    }
+    priceInfo = await priceInfoRes.json();
   }
-  const priceInfo = await priceInfoRes.json();
+
   const now = new Date();
   const priceTime = new Date(priceInfo.timestamp);
   if (now.getTime() - priceTime.getTime() > 900000) {

--- a/src/utils/serverPricer.ts
+++ b/src/utils/serverPricer.ts
@@ -1,0 +1,24 @@
+import { getMainnetConfig, Global, PricerFromApi } from '@strkfarm/sdk';
+
+// Server-only. Prices tokens directly via the strkfarm pricer so server-side
+// callers (e.g. /api/stats, /api/price) don't HTTP-hop through
+// `${getEndpoint()}/api/price`, which depends on HOSTNAME being a correct
+// absolute URL and otherwise falls back to a foreign app (app.troves.fi) that
+// returns a stub payload.
+
+let pricer: PricerFromApi | null = null;
+
+function getPricer() {
+  if (!pricer) {
+    const rpcUrl = process.env.RPC_URL || process.env.NEXT_PUBLIC_RPC_URL;
+    const config = getMainnetConfig(rpcUrl, 'latest');
+    pricer = new PricerFromApi(config, Global.getDefaultTokens());
+  }
+  return pricer;
+}
+
+export async function getServerPrice(
+  symbol: string,
+): Promise<{ price: number; timestamp: Date }> {
+  return getPricer().getPrice(symbol);
+}


### PR DESCRIPTION
## Problem
`GET /api/stats/<address>` returned **500** locally (any address, even `0x0`). The 8 failing strategies were exactly the ekubo CL vaults containing **USDC.e or strkBTC**.

## Root cause
The route prices multi-token vaults via `computeSummaryValue → getValueInQuoteToken → getPrice`. Server-side, `getPrice`'s primary source `getPriceFromMyAPI` does an HTTP self-hop to `${getEndpoint()}/api/price/<sym>`. Server-side `getEndpoint()` = `process.env.HOSTNAME || 'https://app.troves.fi'`; with `HOSTNAME` unset it hits **app.troves.fi** (a different app) whose `/api/price` returns a stub (`{ price: int, timestamp: string }`) → `NaN` → forced **Coinbase** fallback → Coinbase 404s on `USDC.e`/`strkBTC` → `Failed to fetch price`. The route had **no per-strategy error handling**, so that one rejection 500'd the whole portfolio. (Prod returns 200 because its endpoint resolves to the real app.)

The pricer itself is fine — it prices USDC.e=1, strkBTC=58378, STRK=0.0296 correctly; the route just never reached it server-side.

## Fix
- **`utils/serverPricer.ts`** (new): server-only `getServerPrice` via strkfarm `PricerFromApi` (singleton).
- **`getPriceFromMyAPI`**: on the server, call `getServerPrice` directly (dynamic import keeps the SDK out of the client bundle); client path unchanged.
- **`/api/price` route**: refactored to use `getServerPrice` (DRY).
- **`/api/stats` route**: per-strategy `try/catch` so a single failure logs + returns zero holdings instead of 500-ing the endpoint.

## Verified
Local `/api/stats` now returns **200** with priced vaults (e.g. `ekubo_cl_ethusdc.e` non-zero); no more `Failed to fetch price` for USDC.e/strkBTC server-side.