### PR TITLE
fix(ui): block Escape from dismissing T&C modal

### DIFF
--- a/src/components/TncModal.tsx
+++ b/src/components/TncModal.tsx
@@ -162,6 +162,7 @@ const TncModal: React.FC<TncModalProps> = () => {
       <DialogContent
         className="max-w-[32rem] rounded-lg border border-[#7F49E5] bg-[#1A1C26] p-12 text-white [&>button]:hidden"
         onInteractOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
       >
         <div className="flex flex-col items-center justify-center gap-4">
           <DialogHeader>


### PR DESCRIPTION
## What
- Prevent Escape from closing the T&C modal, matching the existing outside-click block.
- Escape used Radix's default handler to close without disconnecting, leaving unregistered wallets connected and un-gated. The gating effect doesn't re-open on local `isOpen` change, so the bypass persisted until navigation/refetch.
- Now the only exits are **Agree** (accept) or **Disconnect** (revert connection).

## Verified
- Pre-commit prettier + eslint + knip passed (0 errors). Escape bypass reasoned through code; not manually exercised in a running app.
