### PR TITLE
fix(api): make T&C accept idempotent, fix P2002 on re-sign

### DIFF
--- a/src/app/api/tnc/accept/route.ts
+++ b/src/app/api/tnc/accept/route.ts
@@ -57,13 +57,24 @@ export async function POST(req: Request) {
         data: {
           isTncSigned: true,
           tncDocVersion: LATEST_TNC_DOC_VERSION,
-          Signatures: {
-            create: {
-              signature: 'click-to-agree',
-              tncDocVersion: LATEST_TNC_DOC_VERSION,
-            },
+        },
+      });
+
+      // Upsert the signature so re-accepting the same version is idempotent
+      // and doesn't violate the (userId, tncDocVersion) unique constraint.
+      await db.signatures.upsert({
+        where: {
+          unique_signature: {
+            userId: existingUser.id,
+            tncDocVersion: LATEST_TNC_DOC_VERSION,
           },
         },
+        create: {
+          userId: existingUser.id,
+          signature: 'click-to-agree',
+          tncDocVersion: LATEST_TNC_DOC_VERSION,
+        },
+        update: {},
       });
 
       mixpanel.track('TnC accepted', {


### PR DESCRIPTION
## What
- `POST /api/tnc/accept` failed with Prisma **P2002** for existing users: the branch always ran a nested `Signatures.create`, so re-accepting the same `tncDocVersion` violated `@@unique([userId, tncDocVersion])`.
- Now upserts the signature on the compound unique — accepting is idempotent.

## Notes
- Reachable whenever a `User`'s `isTncSigned`/`tncDocVersion` drifts out of sync with the `Signatures` table (e.g. re-testing, partial writes): `getUser` reports unsigned, the client re-posts, and the duplicate insert throws.
- Pre-existing bug, independent of the T&C UX change (#68) — affects the current modal flow on `main` too.

## Verified
- `tsc --noEmit` clean; pre-commit lint/format/knip passed. Not exercised against a live DB.
